### PR TITLE
NEW `auth_http` config file parser.

### DIFF
--- a/etc/nanomq_auth_http.conf
+++ b/etc/nanomq_auth_http.conf
@@ -1,0 +1,176 @@
+##--------------------------------------------------------------------
+## HTTP Auth/ACL Plugin
+##--------------------------------------------------------------------
+
+## Enable Authentication/ACL with HTTP API
+##
+## Value: true | false
+auth.http.enable = false
+
+## HTTP URL API path for Auth Request
+##
+## Value: URL
+##
+## Examples: http://127.0.0.1:80/mqtt/auth, https://[::1]:80/mqtt/auth
+auth.http.auth_req.url = http://127.0.0.1:80/mqtt/auth
+
+## HTTP Request Method for Auth Request
+##
+## Value: post | get
+auth.http.auth_req.method = post
+
+## HTTP Request Headers for Auth Request, Content-Type header is configured by default.
+## The possible values of the Content-Type header: application/x-www-form-urlencoded, application/json
+##
+## Examples: auth.http.auth_req.headers.accept = */*
+auth.http.auth_req.headers.content_type = application/x-www-form-urlencoded
+
+## Parameters used to construct the request body or query string parameters
+## When the request method is GET, these parameters will be converted into query string parameters
+## When the request method is POST, the final format is determined by content-type
+##
+## Available Variables:
+##  - %u: username
+##  - %c: clientid
+##  - %a: ipaddress
+##  - %r: protocol
+##  - %P: password
+##  - %p: sockport of server accepted
+##  - %C: common name of client TLS cert
+##  - %d: subject of client TLS cert
+##
+## Value: <K1>=<V1>,<K2>=<V2>,...
+auth.http.auth_req.params = clientid=%c,username=%u,password=%P
+
+## HTTP URL API path for SuperUser Request
+##
+## Value: URL
+##
+## Examples: http://127.0.0.1:80/mqtt/superuser, https://[::1]:80/mqtt/superuser
+# auth.http.super_req.url = http://127.0.0.1:80/mqtt/superuser
+
+## HTTP Request Method for SuperUser Request
+##
+## Value: post | get
+# auth.http.super_req.method = post
+
+## HTTP Request Headers for SuperUser Request, Content-Type header is configured by default.
+## The possible values of the Content-Type header: application/x-www-form-urlencoded, application/json
+##
+## Examples: auth.http.super_req.headers.accept = */*
+# auth.http.super_req.headers.content-type = application/x-www-form-urlencoded
+
+## Parameters used to construct the request body or query string parameters
+## When the request method is GET, these parameters will be converted into query string parameters
+## When the request method is POST, the final format is determined by content-type
+##
+## Available Variables:
+##  - %u: username
+##  - %c: clientid
+##  - %a: ipaddress
+##  - %r: protocol
+##  - %P: password
+##  - %p: sockport of server accepted
+##  - %C: common name of client TLS cert
+##  - %d: subject of client TLS cert
+##
+## Value: <K1>=<V1>,<K2>=<V2>,...
+# auth.http.super_req.params = clientid=%c,username=%u
+
+## HTTP URL API path for ACL Request
+## Comment out this config to disable ACL checks
+##
+## Value: URL
+##
+## Examples: http://127.0.0.1:80/mqtt/acl, https://[::1]:80/mqtt/acl
+auth.http.acl_req.url = http://127.0.0.1:80/mqtt/acl
+
+## HTTP Request Method for ACL Request
+##
+## Value: post | get
+auth.http.acl_req.method = post
+
+## HTTP Request Headers for ACL Request, Content-Type header is configured by default.
+## The possible values of the Content-Type header: application/x-www-form-urlencoded, application/json
+##
+## Examples: auth.http.acl_req.headers.accept = */*
+auth.http.acl_req.headers.content-type = application/x-www-form-urlencoded
+
+## Parameters used to construct the request body or query string parameters
+## When the request method is GET, these parameters will be converted into query string parameters
+## When the request method is POST, the final format is determined by content-type
+##
+## Available Variables:
+##  - %A: access (1 - subscribe, 2 - publish)
+##  - %u: username
+##  - %c: clientid
+##  - %a: ipaddress
+##  - %r: protocol
+##  - %P: password
+##  - %p: sockport of server accepted
+##  - %C: common name of client TLS cert
+##  - %d: subject of client TLS cert
+##  - %t: topic
+##
+## Value: <K1>=<V1>,<K2>=<V2>,...
+auth.http.acl_req.params = access=%A,username=%u,clientid=%c,ipaddr=%a,topic=%t,mountpoint=%m
+
+## Time-out time for the request.
+##
+## Value: Duration
+## -h: hour, e.g. '2h' for 2 hours
+## -m: minute, e.g. '5m' for 5 minutes
+## -s: second, e.g. '30s' for 30 seconds
+##
+## Default: 5s
+auth.http.timeout = 5s
+
+## Connection time-out time, used during the initial request,
+## when the client is connecting to the server.
+##
+## Value: Duration
+## -h: hour, e.g. '2h' for 2 hours
+## -m: minute, e.g. '5m' for 5 minutes
+## -s: second, e.g. '30s' for 30 seconds
+##
+## Default: 5s
+auth.http.connect_timeout = 5s
+
+## Connection process pool size
+##
+## Value: Number
+auth.http.pool_size = 32
+
+##------------------------------------------------------------------------------
+## SSL options
+
+## Path to the file containing PEM-encoded CA certificates. The CA certificates
+## are used during server authentication and when building the client certificate chain.
+##
+## Value: File
+## auth.http.ssl.cacertfile = /etc/emqx/certs/ca.pem
+
+## The path to a file containing the client's certificate.
+##
+## Value: File
+## auth.http.ssl.certfile = /etc/emqx/certs/client-cert.pem
+
+## Path to a file containing the client's private PEM-encoded key.
+##
+## Value: File
+## auth.http.ssl.keyfile = /etc/emqx/certs/client-key.pem
+
+## In mode verify_none the default behavior is to allow all x509-path
+## validation errors.
+##
+## Value: true | false
+## auth.http.ssl.verify = false
+
+## If not specified, the server's names returned in server's certificate is validated against
+## what's provided `auth.http.auth_req.url` config's host part.
+## Setting to 'disable' will make EMQ X ignore unmatched server names.
+## If set with a host name, the server's names returned in server's certificate is validated
+## against this value.
+##
+## Value: String | disable
+## auth.http.ssl.server_name_indication = disable

--- a/nanolib/conf.c
+++ b/nanolib/conf.c
@@ -953,9 +953,9 @@ conf_web_hook_parse_headers(conf_web_hook *webhook, const char *path)
 			webhook->header_count++;
 			webhook->headers = realloc(webhook->headers,
 			    webhook->header_count *
-			        sizeof(conf_web_hook_header *));
+			        sizeof(conf_http_header *));
 			webhook->headers[webhook->header_count - 1] =
-			    calloc(1, sizeof(conf_web_hook_header));
+			    calloc(1, sizeof(conf_http_header));
 			webhook->headers[webhook->header_count - 1]->key =
 			    strtrim_head_tail(key, strlen(key));
 			webhook->headers[webhook->header_count - 1]->value =

--- a/nanolib/conf.c
+++ b/nanolib/conf.c
@@ -14,6 +14,9 @@
 #include "include/file.h"
 #include "nanomq.h"
 
+static conf_http_header **conf_parse_http_headers(
+    const char *path, const char *key_prefix, size_t *count);
+
 static char *
 strtrim(char *str, size_t len)
 {
@@ -185,6 +188,15 @@ get_conf_value(char *line, size_t len, const char *key)
 		free(value);
 		return NULL;
 	}
+}
+
+static char *
+get_conf_value_with_prefix(
+    char *line, size_t len, const char *prefix, const char *key)
+{
+	char str[strlen(prefix) + strlen(key) + 2];
+	sprintf(str, "%s%s", prefix, key);
+	return get_conf_value(line, len, str);
 }
 
 bool
@@ -402,6 +414,44 @@ conf_parser(conf *nanomq_conf)
 	return true;
 }
 
+static void
+conf_tls_init(conf_tls *tls)
+{
+	tls->enable       = false;
+	tls->cafile       = NULL;
+	tls->certfile     = NULL;
+	tls->keyfile      = NULL;
+	tls->ca           = NULL;
+	tls->cert         = NULL;
+	tls->key          = NULL;
+	tls->key_password = NULL;
+	tls->set_fail     = false;
+	tls->verify_peer  = false;
+}
+
+static void
+conf_tls_destroy(conf_tls *tls)
+{
+	zfree(tls->cafile);
+	zfree(tls->certfile);
+	zfree(tls->keyfile);
+	zfree(tls->key);
+	zfree(tls->key_password);
+	zfree(tls->cert);
+	zfree(tls->ca);
+}
+
+static void
+conf_auth_http_req_init(conf_auth_http_req *req)
+{
+	req->url          = NULL;
+	req->method       = NULL;
+	req->header_count = 0;
+	req->headers      = NULL;
+	req->param_count  = 0;
+	req->params       = NULL;
+}
+
 void
 conf_init(conf *nanomq_conf)
 {
@@ -410,6 +460,7 @@ conf_init(conf *nanomq_conf)
 	nanomq_conf->bridge_file      = NULL;
 	nanomq_conf->web_hook_file    = NULL;
 	nanomq_conf->auth_file        = NULL;
+	nanomq_conf->auth_http_file   = NULL;
 	nanomq_conf->num_taskq_thread = 10;
 	nanomq_conf->max_taskq_thread = 10;
 	nanomq_conf->parallel         = 30; // not work
@@ -419,16 +470,7 @@ conf_init(conf *nanomq_conf)
 	nanomq_conf->allow_anonymous  = true;
 	nanomq_conf->daemon           = false;
 
-	nanomq_conf->tls.enable       = false;
-	nanomq_conf->tls.cafile       = NULL;
-	nanomq_conf->tls.certfile     = NULL;
-	nanomq_conf->tls.keyfile      = NULL;
-	nanomq_conf->tls.ca           = NULL;
-	nanomq_conf->tls.cert         = NULL;
-	nanomq_conf->tls.key          = NULL;
-	nanomq_conf->tls.key_password = NULL;
-	nanomq_conf->tls.set_fail     = false;
-	nanomq_conf->tls.verify_peer  = false;
+	conf_tls_init(&nanomq_conf->tls);
 
 	nanomq_conf->http_server.enable              = false;
 	nanomq_conf->http_server.port                = 8081;
@@ -448,26 +490,26 @@ conf_init(conf *nanomq_conf)
 	nanomq_conf->bridge.bridge_mode = false;
 	nanomq_conf->bridge.sub_count   = 0;
 	nanomq_conf->bridge.parallel    = 1;
+	conf_tls_init(&nanomq_conf->bridge.tls);
 
-	nanomq_conf->web_hook.enable           = false;
-	nanomq_conf->web_hook.url              = NULL;
-	nanomq_conf->web_hook.encode_payload   = plain;
-	nanomq_conf->web_hook.pool_size        = 8;
-	nanomq_conf->web_hook.headers          = NULL;
-	nanomq_conf->web_hook.header_count     = 0;
-	nanomq_conf->web_hook.rules            = NULL;
-	nanomq_conf->web_hook.rule_count       = 0;
-	nanomq_conf->web_hook.tls.enable       = false;
-	nanomq_conf->web_hook.tls.enable       = false;
-	nanomq_conf->web_hook.tls.cafile       = NULL;
-	nanomq_conf->web_hook.tls.certfile     = NULL;
-	nanomq_conf->web_hook.tls.keyfile      = NULL;
-	nanomq_conf->web_hook.tls.ca           = NULL;
-	nanomq_conf->web_hook.tls.cert         = NULL;
-	nanomq_conf->web_hook.tls.key          = NULL;
-	nanomq_conf->web_hook.tls.key_password = NULL;
-	nanomq_conf->web_hook.tls.set_fail     = false;
-	nanomq_conf->web_hook.tls.verify_peer  = false;
+	nanomq_conf->web_hook.enable         = false;
+	nanomq_conf->web_hook.url            = NULL;
+	nanomq_conf->web_hook.encode_payload = plain;
+	nanomq_conf->web_hook.pool_size      = 32;
+	nanomq_conf->web_hook.headers        = NULL;
+	nanomq_conf->web_hook.header_count   = 0;
+	nanomq_conf->web_hook.rules          = NULL;
+	nanomq_conf->web_hook.rule_count     = 0;
+	conf_tls_init(&nanomq_conf->web_hook.tls);
+
+	nanomq_conf->auth_http.enable = false;
+	conf_auth_http_req_init(&nanomq_conf->auth_http.auth_req);
+	conf_auth_http_req_init(&nanomq_conf->auth_http.super_req);
+	conf_auth_http_req_init(&nanomq_conf->auth_http.acl_req);
+	nanomq_conf->auth_http.timeout   = 5;
+	nanomq_conf->auth_http.timeout   = 5;
+	nanomq_conf->auth_http.pool_size = 32;
+	conf_tls_init(&nanomq_conf->auth_http.tls);
 }
 
 void
@@ -894,6 +936,7 @@ conf_bridge_destroy(conf_bridge *bridge)
 		}
 		free(bridge->sub_list);
 	}
+	conf_tls_destroy(&bridge->tls);
 }
 
 void
@@ -924,60 +967,6 @@ print_bridge_conf(conf_bridge *bridge)
 		    bridge->sub_list[i].qos);
 	}
 	debug_msg("");
-}
-
-bool
-conf_web_hook_parse_headers(conf_web_hook *webhook, const char *path)
-{
-	FILE *fp;
-	if ((fp = fopen(path, "r")) == NULL) {
-		debug_msg("File %s open failed", path);
-		return false;
-	}
-
-	char * line = NULL;
-	size_t sz   = 0;
-
-	webhook->header_count = 0;
-	while (nano_getline(&line, &sz, fp) != -1) {
-		if (sz <= 16) {
-			goto next;
-		}
-		char *key   = calloc(1, sz - 16);
-		char *value = calloc(1, sz - 16);
-		char *str = strtrim_head_tail(line, sz);
-		int   res =
-		    sscanf(str, "web.hook.headers.%[^=]=%[^\n]", key, value);
-		free(str);
-		if (res == 2) {
-			webhook->header_count++;
-			webhook->headers = realloc(webhook->headers,
-			    webhook->header_count *
-			        sizeof(conf_http_header *));
-			webhook->headers[webhook->header_count - 1] =
-			    calloc(1, sizeof(conf_http_header));
-			webhook->headers[webhook->header_count - 1]->key =
-			    strtrim_head_tail(key, strlen(key));
-			webhook->headers[webhook->header_count - 1]->value =
-			    strtrim_head_tail(value, strlen(value));
-		}
-		if (key) {
-			free(key);
-		}
-		if (value) {
-			free(value);
-		}
-
-	next:
-		free(line);
-		line = NULL;
-	}
-
-	if (line) {
-		free(line);
-	}
-	fclose(fp);
-	return true;
 }
 
 static webhook_event
@@ -1063,7 +1052,7 @@ conf_web_hook_parse_rules(conf_web_hook *webhook, const char *path)
 		char *   hookname = NULL;
 		uint16_t num      = 0;
 		char *   str      = strtrim_head_tail(line, sz);
-		int res =
+		int      res =
 		    sscanf(str, "web.hook.rule.%[^=]=%[^\n]", key, value);
 		free(str);
 		bool  match         = false;
@@ -1186,7 +1175,8 @@ conf_web_hook_parse(conf *nanomq_conf)
 	}
 	fclose(fp);
 
-	conf_web_hook_parse_headers(webhook, dest_path);
+	webhook->headers = conf_parse_http_headers(
+	    dest_path, "web.hook", &webhook->header_count);
 	conf_web_hook_parse_rules(webhook, dest_path);
 	return true;
 }
@@ -1198,6 +1188,8 @@ conf_web_hook_destroy(conf_web_hook *web_hook)
 
 	if (web_hook->header_count > 0 && web_hook->headers != NULL) {
 		for (size_t i = 0; i < web_hook->header_count; i++) {
+			zfree(web_hook->headers[i]->key);
+			zfree(web_hook->headers[i]->value);
 			zfree(web_hook->headers[i]);
 		}
 		zfree(web_hook->headers);
@@ -1212,13 +1204,304 @@ conf_web_hook_destroy(conf_web_hook *web_hook)
 		zfree(web_hook->rules);
 	}
 
-	zfree(web_hook->tls.cafile);
-	zfree(web_hook->tls.certfile);
-	zfree(web_hook->tls.keyfile);
-	zfree(web_hook->tls.key);
-	zfree(web_hook->tls.key_password);
-	zfree(web_hook->tls.cert);
-	zfree(web_hook->tls.ca);
+	conf_tls_destroy(&web_hook->tls);
+}
+
+static int
+get_time(const char *str, uint64_t *second)
+{
+	char     unit = 0;
+	uint64_t s    = 0;
+	if (2 == sscanf(str, "%llu%c", &s, &unit)) {
+		switch (unit) {
+		case 's':
+			*second = s;
+			break;
+		case 'm':
+			*second = s * 60;
+			break;
+		case 'h':
+			*second = s * 3600;
+			break;
+		default:
+			break;
+		}
+		return 0;
+	}
+	return -1;
+}
+
+static conf_http_header **
+conf_parse_http_headers(
+    const char *path, const char *key_prefix, size_t *count)
+{
+	FILE *fp;
+	if ((fp = fopen(path, "r")) == NULL) {
+		debug_msg("File %s open failed", path);
+		return NULL;
+	}
+
+	char *             line = NULL;
+	size_t             sz   = 0;
+	conf_http_header **headers;
+
+	char pattern[strlen(key_prefix) + 23];
+	sprintf(pattern, "%s.headers.%%[^=]=%%[^\n]", key_prefix);
+
+	size_t header_count = 0;
+	while (nano_getline(&line, &sz, fp) != -1) {
+		if (sz <= 16) {
+			goto next;
+		}
+		char *key   = calloc(1, sz - 16);
+		char *value = calloc(1, sz - 16);
+		char *str   = strtrim_head_tail(line, sz);
+		int   res   = sscanf(str, pattern, key, value);
+		free(str);
+		if (res == 2) {
+			header_count++;
+			headers = realloc(headers,
+			    header_count * sizeof(conf_http_header *));
+			headers[header_count - 1] =
+			    calloc(1, sizeof(conf_http_header));
+			headers[header_count - 1]->key =
+			    strtrim_head_tail(key, strlen(key));
+			headers[header_count - 1]->value =
+			    strtrim_head_tail(value, strlen(value));
+		}
+		if (key) {
+			free(key);
+		}
+		if (value) {
+			free(value);
+		}
+
+	next:
+		free(line);
+		line = NULL;
+	}
+
+	if (line) {
+		free(line);
+	}
+	fclose(fp);
+	*count = header_count;
+	return headers;
+}
+
+static conf_http_param **
+get_params(const char *value, size_t *count)
+{
+	conf_http_param **params      = NULL;
+	size_t            param_count = 0;
+
+	char *line = strdup(value);
+	char *tk   = strtok(line, ",");
+	while (tk != NULL) {
+		param_count++;
+		params =
+		    realloc(params, sizeof(conf_http_param *) * param_count);
+		char *str = strdup(tk);
+		char *key = calloc(1, strlen(str));
+		char  c   = 0;
+		int   res = sscanf(str, "%[^=]=%%%c", key, &c);
+		if (res == 2) {
+			params[param_count - 1] =
+			    calloc(1, sizeof(conf_http_param));
+			params[param_count - 1]->name = key;
+			switch (c) {
+			case 'A':
+				params[param_count - 1]->type = ACCESS;
+				break;
+			case 'u':
+				params[param_count - 1]->type = USERNAME;
+				break;
+			case 'c':
+				params[param_count - 1]->type = CLIENTID;
+				break;
+			case 'a':
+				params[param_count - 1]->type = IPADDRESS;
+				break;
+			case 'P':
+				params[param_count - 1]->type = PASSWORD;
+				break;
+			case 'p':
+				params[param_count - 1]->type = SOCKPORT;
+				break;
+			case 'C':
+				params[param_count - 1]->type = COMMON_NAME;
+				break;
+			case 'd':
+				params[param_count - 1]->type = SUBJECT;
+				break;
+			case 't':
+				params[param_count - 1]->type = TOPIC;
+				break;
+			default:
+				break;
+			}
+		} else {
+			param_count--;
+			if (key) {
+				free(key);
+			}
+		}
+		free(str);
+		tk = strtok(NULL, ",");
+	}
+	if (line) {
+		free(line);
+	}
+	*count = param_count;
+	
+	return params;
+}
+
+static bool
+conf_auth_http_req_parse(
+    conf_auth_http_req *req, const char *path, const char *key_prefix)
+{
+	FILE *fp;
+	if ((fp = fopen(path, "r")) == NULL) {
+		debug_msg("File %s open failed", path);
+		return false;
+	}
+	char * line = NULL;
+	size_t sz   = 0;
+
+	char *value;
+	while (nano_getline(&line, &sz, fp) != -1) {
+		if ((value = get_conf_value_with_prefix(
+		         line, sz, key_prefix, ".url")) != NULL) {
+			req->url = value;
+		} else if ((value = get_conf_value_with_prefix(
+		                line, sz, key_prefix, ".method")) != NULL) {
+			if (strcasecmp(value, "post") == 0 ||
+			    strcasecmp(value, "get") == 0) {
+				req->method = value;
+			} else {
+				free(value);
+				req->method = strdup("post");
+			}
+		} else if ((value = get_conf_value_with_prefix(
+		                line, sz, key_prefix, ".params")) != NULL) {
+			req->params = get_params(value, &req->param_count);
+			free(value);
+		}
+
+		free(line);
+		line = NULL;
+	}
+
+	if (line) {
+		free(line);
+	}
+	fclose(fp);
+
+	req->headers =
+	    conf_parse_http_headers(path, key_prefix, &req->header_count);
+
+	return true;
+}
+
+bool
+conf_auth_http_parse(conf *nanomq_conf)
+{
+	const char *dest_path = nanomq_conf->auth_http_file;
+
+	if (dest_path == NULL || !nano_file_exists(dest_path)) {
+		if (!nano_file_exists(CONF_AUTH_HTTP_PATH_NAME)) {
+			debug_msg("Configure file [%s] or [%s] not found or "
+			          "unreadable",
+			    dest_path, CONF_AUTH_HTTP_PATH_NAME);
+			return false;
+		} else {
+			dest_path = CONF_AUTH_HTTP_PATH_NAME;
+		}
+	}
+
+	char * line = NULL;
+	size_t sz   = 0;
+	FILE * fp;
+
+	conf_auth_http *auth_http = &nanomq_conf->auth_http;
+
+	if ((fp = fopen(dest_path, "r")) == NULL) {
+		debug_msg("File %s open failed", dest_path);
+		auth_http->enable = false;
+		return true;
+	}
+	char *value;
+	while (nano_getline(&line, &sz, fp) != -1) {
+		if ((value = get_conf_value(line, sz, "auth.http.enable")) !=
+		    NULL) {
+			auth_http->enable = strcasecmp(value, "true") == 0;
+			free(value);
+		} else if ((value = get_conf_value(
+		                line, sz, "auth.http.timeout")) != NULL) {
+			get_time(value, &auth_http->timeout);
+			free(value);
+		} else if ((value = get_conf_value(line, sz,
+		                "auth.http.connect_timeout")) != NULL) {
+			get_time(value, &auth_http->connect_timeout);
+			free(value);
+		} else if ((value = get_conf_value(line, sz,
+		                "auth.http.connect_timeout")) != NULL) {
+			get_time(value, &auth_http->connect_timeout);
+			free(value);
+		} else if ((value = get_conf_value(
+		                line, sz, "auth.http.pool_size")) != NULL) {
+			auth_http->pool_size = (size_t) atol(value);
+			free(value);
+		}
+
+		free(line);
+		line = NULL;
+	}
+	if (line) {
+		free(line);
+	}
+	fclose(fp);
+
+	conf_auth_http_req_parse(
+	    &auth_http->auth_req, dest_path, "auth.http.auth_req");
+	conf_auth_http_req_parse(
+	    &auth_http->super_req, dest_path, "auth.http.super_req");
+	conf_auth_http_req_parse(
+	    &auth_http->acl_req, dest_path, "auth.http.acl_req");
+
+	return true;
+}
+
+static void
+conf_auth_http_req_destroy(conf_auth_http_req *req)
+{
+	zfree(req->url);
+	if (req->header_count > 0 && req->headers != NULL) {
+		for (size_t i = 0; i < req->header_count; i++) {
+			zfree(req->headers[i]->key);
+			zfree(req->headers[i]->value);
+			zfree(req->headers[i]);
+		}
+		zfree(req->headers);
+	}
+
+	if (req->param_count > 0 && req->params != NULL) {
+		for (size_t i = 0; i < req->param_count; i++) {
+			zfree(req->params[i]->name);
+			zfree(req->params[i]);
+		}
+		zfree(req->params);
+	}
+}
+
+void
+conf_auth_http_destroy(conf_auth_http *auth_http)
+{
+	conf_auth_http_req_destroy(&auth_http->auth_req);
+	conf_auth_http_req_destroy(&auth_http->super_req);
+	conf_auth_http_req_destroy(&auth_http->acl_req);
+	conf_tls_destroy(&auth_http->tls);
 }
 
 void
@@ -1240,14 +1523,7 @@ conf_fini(conf *nanomq_conf)
 	zfree(nanomq_conf->bridge_file);
 	zfree(nanomq_conf->web_hook_file);
 	zfree(nanomq_conf->auth_file);
-
-	zfree(nanomq_conf->tls.cafile);
-	zfree(nanomq_conf->tls.certfile);
-	zfree(nanomq_conf->tls.keyfile);
-	zfree(nanomq_conf->tls.key);
-	zfree(nanomq_conf->tls.key_password);
-	zfree(nanomq_conf->tls.cert);
-	zfree(nanomq_conf->tls.ca);
+	conf_tls_destroy(&nanomq_conf->tls);
 
 	zfree(nanomq_conf->http_server.username);
 	zfree(nanomq_conf->http_server.password);
@@ -1260,6 +1536,7 @@ conf_fini(conf *nanomq_conf)
 
 	conf_bridge_destroy(&nanomq_conf->bridge);
 	conf_web_hook_destroy(&nanomq_conf->web_hook);
+	conf_auth_http_destroy(&nanomq_conf->auth_http);
 
 	free(nanomq_conf);
 }

--- a/nanolib/conf.c
+++ b/nanolib/conf.c
@@ -1241,9 +1241,9 @@ conf_parse_http_headers(
 		return NULL;
 	}
 
-	char *             line = NULL;
-	size_t             sz   = 0;
-	conf_http_header **headers;
+	char *             line    = NULL;
+	size_t             sz      = 0;
+	conf_http_header **headers = NULL;
 
 	char pattern[strlen(key_prefix) + 23];
 	sprintf(pattern, "%s.headers.%%[^=]=%%[^\n]", key_prefix);

--- a/nanolib/include/conf.h
+++ b/nanolib/include/conf.h
@@ -18,6 +18,7 @@
 #define CONF_BRIDGE_PATH_NAME "/etc/nanomq_bridge.conf"
 #define CONF_GATEWAY_PATH_NAME "/etc/nanomq_gateway.conf"
 #define CONF_WEB_HOOK_PATH_NAME "/etc/nanomq_web_hook.conf"
+#define CONF_AUTH_HTTP_PATH_NAME "/etc/nanomq_auth_http.conf"
 
 #define CONF_TCP_URL_DEFAULT "nmq-tcp://0.0.0.0:1883"
 #define CONF_TLS_URL_DEFAULT "tls+nmq-tcp://0.0.0.0:8883"
@@ -61,6 +62,58 @@ struct conf_tls {
 };
 
 typedef struct conf_tls conf_tls;
+
+struct conf_http_header {
+	char *key;
+	char *value;
+};
+
+typedef struct conf_http_header conf_http_header;
+
+typedef enum {
+	ACCESS,
+	USERNAME,
+	CLIENTID,
+	IPADDRESS,
+	PROTOCOL,
+	PASSWORD,
+	SOCKPORT,    // sockport of server accepted
+	COMMON_NAME, // common name of client TLS cert
+	SUBJECT,     // subject of client TLS cert
+	TOPIC,
+} http_param_type;
+
+struct conf_http_param {
+	char *          name;
+	http_param_type type;
+};
+
+typedef struct conf_http_param conf_http_param;
+
+struct conf_auth_http_req {
+	char *url;
+	char *method;
+	size_t header_count;
+	conf_http_header **headers;
+	size_t param_count;
+	conf_http_param **params;
+};
+
+typedef struct conf_auth_http_req conf_auth_http_req;
+
+struct conf_auth_http {
+	bool               enable;
+	conf_auth_http_req auth_req;
+	conf_auth_http_req super_req;
+	conf_auth_http_req acl_req;
+	uint64_t           timeout;         // seconds
+	uint64_t           connect_timeout; // seconds
+	size_t             pool_size;
+	// TODO not support yet
+	conf_tls tls;
+};
+
+typedef struct conf_auth_http conf_auth_http;
 
 struct conf_jwt {
 	char *iss;
@@ -167,20 +220,13 @@ struct conf_web_hook_rule {
 
 typedef struct conf_web_hook_rule conf_web_hook_rule;
 
-struct conf_web_hook_header {
-	char *key;
-	char *value;
-};
-
-typedef struct conf_web_hook_header conf_web_hook_header;
-
 struct conf_web_hook {
 	bool   enable;
 	char * url;
 	size_t pool_size;
 	hook_payload_type encode_payload;
 	size_t header_count;
-	conf_web_hook_header **headers;
+	conf_http_header **headers;
 
 	uint16_t            rule_count;
 	conf_web_hook_rule **rules;
@@ -194,8 +240,9 @@ typedef struct conf_web_hook  conf_web_hook;
 struct conf {
 	char *   conf_file;
 	char *   bridge_file;
-	char * 	 web_hook_file;
+	char *   web_hook_file;
 	char *   auth_file;
+	char *   auth_http_file;
 	char *   url; // "nmq-tcp://addr:port"
 	int      num_taskq_thread;
 	int      max_taskq_thread;
@@ -213,7 +260,8 @@ struct conf {
 	conf_bridge      bridge;
 	conf_web_hook    web_hook;
 
-	conf_auth auths;
+	conf_auth      auths;
+	conf_auth_http auth_http;
 };
 
 typedef struct conf conf;

--- a/nanolib/include/conf.h
+++ b/nanolib/include/conf.h
@@ -166,6 +166,7 @@ struct conf_bridge {
 	size_t     sub_count;
 	subscribe *sub_list;
 	uint64_t   parallel;
+	conf_tls   tls;
 };
 
 typedef struct {
@@ -270,6 +271,7 @@ extern bool conf_parser(conf *nanomq_conf);
 extern bool conf_bridge_parse(conf *nanomq_conf);
 extern bool conf_gateway_parse(zmq_gateway_conf *g_conf);
 extern bool conf_web_hook_parse(conf *nanomq_conf);
+extern bool conf_auth_http_parse(conf *nanomq_conf);
 extern void print_bridge_conf(conf_bridge *bridge);
 extern void conf_init(conf *nanomq_conf);
 extern void print_conf(conf *nanomq_conf);

--- a/nanomq/apps/broker.c
+++ b/nanomq/apps/broker.c
@@ -56,6 +56,7 @@ enum options {
 	OPT_BRIDGEFILE,
 	OPT_WEBHOOKFILE,
 	OPT_AUTHFILE,
+	OPT_AUTH_HTTP_FILE,
 	OPT_PARALLEL,
 	OPT_DAEMON,
 	OPT_THREADS,
@@ -80,6 +81,7 @@ static nng_optspec cmd_opts[] = {
 	{ .o_name = "bridge", .o_val = OPT_BRIDGEFILE, .o_arg = true },
 	{ .o_name = "webhook", .o_val = OPT_WEBHOOKFILE, .o_arg = true },
 	{ .o_name = "auth", .o_val = OPT_AUTHFILE, .o_arg = true },
+	{ .o_name = "auth_http", .o_val = OPT_AUTH_HTTP_FILE, .o_arg = true },
 	{ .o_name = "daemon", .o_short = 'd', .o_val = OPT_DAEMON },
 	{ .o_name    = "tq_thread",
 	    .o_short = 't',
@@ -822,8 +824,9 @@ print_usage(void)
 	       "[--bridge <path>] \n                     "
 	       "[--webhook <path>] "
 		   "[--auth <path>] "
-	       "[-d, --daemon] "
-	       "[-t, --tq_thread <num>] \n                     "
+		   "[--auth_http <path>] "
+	       "[-d, --daemon] \n                     "
+	       "[-t, --tq_thread <num>] "
 	       "[-T, -max_tq_thread <num>] [-n, "
 	       "--parallel <num>]\n                     "
 	       "[-D, --qos_duration <num>] [--http] "
@@ -848,6 +851,9 @@ print_usage(void)
 	printf(
 	    "  --auth <path>              The path of a specified authorize "
 	    "configuration file \n");
+	printf("  --auth_http <path>         The path of a specified http "
+	       "authorize "
+	       "configuration file \n");
 	printf("  --http                     Enable http server (default: "
 	       "false)\n");
 	printf(
@@ -1015,6 +1021,10 @@ broker_parse_opts(int argc, char **argv, conf *config)
 			FREE_NONULL(config->auth_file);
 			config->auth_file = nng_strdup(arg);
 			break;
+		case OPT_AUTH_HTTP_FILE:
+			FREE_NONULL(config->auth_http_file);
+			config->auth_http_file = nng_strdup(arg);
+			break;
 		case OPT_PARALLEL:
 			config->parallel = atoi(arg);
 			break;
@@ -1128,6 +1138,7 @@ broker_start(int argc, char **argv)
 	conf_init(nanomq_conf);
 	conf_parser(nanomq_conf);
 	conf_bridge_parse(nanomq_conf);
+	conf_auth_http_parse(nanomq_conf);
 	read_env_conf(nanomq_conf);
 
 	if (!broker_parse_opts(argc, argv, nanomq_conf)) {
@@ -1143,6 +1154,9 @@ broker_start(int argc, char **argv)
 	}
 	if (nanomq_conf->web_hook_file) {
 		conf_web_hook_parse(nanomq_conf);
+	}
+	if (nanomq_conf->auth_http_file) {
+		conf_auth_http_parse(nanomq_conf);
 	}
 
 	nanomq_conf->url = nanomq_conf->url != NULL


### PR DESCRIPTION
1. Add config file `etc/nanomq_auth_http.conf`;
2. Add data structure `conf_auth_http`;
3. Add parse function `conf_auth_http_parse()`;
4. Add cmd argument `--auth_http <path>`;