### PR TITLE
Setting number of taskq and parallel automatically

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -151,7 +151,6 @@ message(STATUS "Configuring for NanoMQ version ${NANO_ABI_VERSION}")
 SET(DEBUG 0 CACHE STRING "gdb support")
 SET(ASAN 0 CACHE STRING "asan support")
 SET(TSAN 0 CACHE STRING "tsan support")
-SET(PARALLEL 32 CACHE STRING "Parallelism (min 4, max 1000)")
 
 if(BUILD_NANO_LIB)
   add_definitions(-DSUPP_NANO_LIB)

--- a/etc/nanomq.conf
+++ b/etc/nanomq.conf
@@ -56,13 +56,13 @@ client_max_packet_size=1024
 ## This is essential for performance and memory consumption
 ##
 ## Value: 1-infinity
-msq_len=256
+msq_len=2048
 
 ## qos_duration (s)
 ## The nano qos duration which also controls timer interval of each pipe
 ##
 ## Value: 1-infinity
-qos_duration=5
+qos_duration=10
 
 ## The backoff for MQTT keepalive timeout.
 ## broker will discolse client when there is no activity for

--- a/etc/nanomq.conf
+++ b/etc/nanomq.conf
@@ -17,20 +17,20 @@ daemon=false
 ## num_taskq_thread
 ## Use a specified number of taskq threads 
 ##
-## Value: 1-255
-num_taskq_thread=4
+## Value: 1-255, Obtain automatically if 0
+num_taskq_thread=0
 
 ## max_taskq_thread
 ## Use a specified maximunm number of taskq threads
 ##
-## Value: 1-255
-max_taskq_thread=4
+## Value: 1-255, Obtain automatically if 0
+max_taskq_thread=0
 
 ## parallel
 ## Handle a specified maximum number of outstanding requests
 ##
-## Value: 1-infinity
-parallel=32
+## Value: 1-255, Obtain automatically if 0
+parallel=0
 
 ## Property_size
 ## The max size for a MQTT user property
@@ -58,11 +58,11 @@ client_max_packet_size=1024
 ## Value: 1-infinity
 msq_len=256
 
-## qos_duration
+## qos_duration (s)
 ## The nano qos duration which also controls timer interval of each pipe
 ##
 ## Value: 1-infinity
-qos_duration=60
+qos_duration=5
 
 ## The backoff for MQTT keepalive timeout.
 ## broker will discolse client when there is no activity for

--- a/nanomq/apps/broker.c
+++ b/nanomq/apps/broker.c
@@ -1485,10 +1485,7 @@ broker_start(int argc, char **argv)
 		exit(EXIT_FAILURE);
 	}
 
-	nanomq_conf->parallel = PARALLEL;
-
 	// Priority: config < environment variables < command opts
-
 	conf_init(nanomq_conf);
 	read_env_conf(nanomq_conf);
 

--- a/nanomq_cli/quic_client.c
+++ b/nanomq_cli/quic_client.c
@@ -36,8 +36,9 @@
 #if defined(SUPP_QUIC)
 
 #include <nng/nng.h>
-#include "nng/mqtt/mqtt_client.h"
-#include "nng/mqtt/mqtt_quic.h"
+#include <nng/mqtt/mqtt_client.h>
+#include <nng/mqtt/mqtt_quic.h>
+#include <nng/supplemental/util/platform.h>
 
 #include <stdio.h>
 #include <stdlib.h>


### PR DESCRIPTION
+ Setting number of taskq and parallel automatically
+ Remove PARALLEL in cmake to simplify user setting.
+ Adjust default qos duration and capacity of msq.
+ Fix some warnings on OSX.