### PR TITLE
extend apt commands to make Docker images smaller

### DIFF
--- a/deploy/docker/Dockerfile-full
+++ b/deploy/docker/Dockerfile-full
@@ -3,7 +3,7 @@ FROM gcc:11 as builder
 COPY . /nanomq
 
 RUN apt update \
-    && apt install -y cmake ninja-build libmbedtls-dev libtool pkg-config build-essential autoconf automake g++ \
+    && DEBIAN_FRONTEND=noninteractive apt install -y --no-install-recommends cmake ninja-build libmbedtls-dev libtool pkg-config build-essential autoconf automake g++ \
     && rm -rf /var/lib/apt/lists/*
 
 WORKDIR /tmp/zeromq
@@ -47,7 +47,7 @@ COPY deploy/docker/docker-entrypoint.sh /usr/bin/docker-entrypoint.sh
 RUN ln -s /usr/local/nanomq/nanomq /usr/bin/nanomq && \
     ln -s /usr/local/nanomq/nanomq_cli /usr/bin/nanomq_cli
 
-RUN apt update && apt install -y libatomic1
+RUN apt update && DEBIAN_FRONTEND=noninteractive apt install -y --no-install-recommends libatomic1 && rm -rf /var/lib/apt/lists/*
 
 EXPOSE 1883 8883 8081
 

--- a/deploy/docker/Dockerfile-slim
+++ b/deploy/docker/Dockerfile-slim
@@ -2,7 +2,7 @@ FROM gcc:11 as builder
 
 COPY . /nanomq
 
-RUN apt update && apt install -y cmake
+RUN apt update && DEBIAN_FRONTEND=noninteractive apt install -y --no-install-recommends  cmake && rm -rf /var/lib/apt/lists/*
 
 WORKDIR /nanomq/build
 
@@ -20,7 +20,7 @@ COPY deploy/docker/docker-entrypoint.sh /usr/bin/docker-entrypoint.sh
 RUN ln -s /usr/local/nanomq/nanomq /usr/bin/nanomq && \
     ln -s /usr/local/nanomq/nanomq_cli /usr/bin/nanomq_cli
 
-RUN apt update && apt install -y libatomic1
+RUN apt update && DEBIAN_FRONTEND=noninteractive apt install -y --no-install-recommends libatomic1 && rm -rf /var/lib/apt/lists/*
 
 EXPOSE 1883
 


### PR DESCRIPTION
By following the [Docker best practices](https://docs.docker.com/develop/develop-images/dockerfile_best-practices/#run) we can make the docker images slightly smaller