### PR TITLE
Replace deb package from dockerfile-full

### DIFF
--- a/.github/workflows/build_packages.yaml
+++ b/.github/workflows/build_packages.yaml
@@ -131,14 +131,17 @@ jobs:
         make_flags="-DCMAKE_C_COMPILER=${{ matrix.arch[1] }} -DCMAKE_CXX_COMPILER=${{ matrix.arch[2] }} -DNNG_ENABLE_TLS=ON"
        
         if [ "${{ matrix.build_type }}" == "-sqlite" ] || [ "${{ matrix.build_type }}" == "-full" ]; then
-          make_flags+=" -DNNG_ENABLE_SQLITE=ON"
+          make_flags+=" -DNNG_ENABLE_SQLITE=ON "
         fi
         
         if [ "${{ matrix.build_type }}" == "-msquic" ] || [ "${{ matrix.build_type }}" == "-full" ]; then
           make_flags+=" -DNNG_ENABLE_QUIC=ON "
+          make_flags+=" -DNNG_ENABLE_SQLITE=ON "
           make_flags+=" -DQUIC_BUILD_SHARED=OFF "
           if [ "$arch" != "x86_64" ] && [ "$arch" != "amd64" ]; then
             make_flags+=" -DONEBRANCH=1 "
+            make_flags+=" -DCMAKE_CROSSCOMPILING=ON "
+            make_flags+=" -DCMAKE_PREFIX_PATH=${{ matrix.arch[4] }} "
             if [ "$arch" == "arm64" ]; then
               make_flags+=" -DCMAKE_TARGET_ARCHITECTURE=arm64 "
               make_flags+=" -DGNU_MACHINE=aarch64-linux-gnu "
@@ -155,10 +158,6 @@ jobs:
           make_flags+=" -DENABLE_JWT=ON "
           make_flags+=" -DBUILD_ZMQ_GATEWAY=ON "
           make_flags+=" -DBUILD_BENCH=ON "
-          if [ "$arch" != "x86_64" ] && [ "$arch" != "amd64" ]; then
-            make_flags+=" -DCMAKE_CROSSCOMPILING=ON "
-            make_flags+=" -DCMAKE_PREFIX_PATH=${{ matrix.arch[4] }} "
-          fi
         fi
 
         echo "arch=${arch}" >> $GITHUB_OUTPUT

--- a/.github/workflows/build_packages.yaml
+++ b/.github/workflows/build_packages.yaml
@@ -156,8 +156,6 @@ jobs:
           make_flags+=" -DBUILD_BENCH=ON "
           if [ "$arch" != "x86_64" ] && [ "$arch" != "amd64" ]; then
             make_flags+=" -DCMAKE_CROSSCOMPILING=ON "
-            make_flags+=" -DCMAKE_STAGING_PREFIX=${{ matrix.arch[4] }} "
-            make_flags+=" -DCMAKE_INSTALL_PREFIX=${{ matrix.arch[4] }} "
             make_flags+=" -DCMAKE_PREFIX_PATH=${{ matrix.arch[4] }} "
           fi
         fi

--- a/.github/workflows/build_packages.yaml
+++ b/.github/workflows/build_packages.yaml
@@ -135,7 +135,8 @@ jobs:
         fi
         
         if [ "${{ matrix.build_type }}" == "-msquic" ] || [ "${{ matrix.build_type }}" == "-full" ]; then
-          make_flags+=" -DNNG_ENABLE_QUIC=ON"
+          make_flags+=" -DNNG_ENABLE_QUIC=ON "
+          make_flags+=" -DQUIC_BUILD_SHARED=OFF "
           if [ "$arch" != "x86_64" ] && [ "$arch" != "amd64" ]; then
             make_flags+=" -DONEBRANCH=1 "
             if [ "$arch" == "arm64" ]; then

--- a/deploy/docker/Dockerfile-dev
+++ b/deploy/docker/Dockerfile-dev
@@ -13,13 +13,12 @@ RUN wget https://github.com/zeromq/libzmq/releases/download/v4.3.4/zeromq-4.3.4.
     && cd zeromq-4.3.4 \
     && mkdir build \
     && cd build \
-    && cmake -DWITH_PERF_TOOL=OFF  \
+    && cmake -DBUILD_SHARED=OFF   \
     -DZMQ_BUILD_TESTS=OFF  \
     -DENABLE_CPACK=OFF  \
     -DWITH_DOC=OFF \
     -DCMAKE_BUILD_TYPE=Release .. \
-    && make install \
-    && ldconfig
+    && make install 
 
 WORKDIR /nanomq/build
 
@@ -29,8 +28,8 @@ RUN cmake -DENABLE_JWT=ON \
     -DQUIC_USE_SYSTEM_LIBCRYPTO=ON \
     -DNNG_ENABLE_SQLITE=ON \
     -DBUILD_ZMQ_GATEWAY=ON \
-    -DBUILD_BENCH=ON .. && \
-    make -msoft-float
+    -DBUILD_BENCH=ON .. \
+    && make
 
 FROM debian:11-slim
 
@@ -39,8 +38,6 @@ WORKDIR /usr/local/nanomq
 COPY --from=builder /nanomq/build/nanomq/nanomq /usr/local/nanomq/
 COPY --from=builder /nanomq/build/nanomq_cli/nanomq_cli /usr/local/nanomq/
 COPY --from=builder /nanomq/build/nng/src/supplemental/quic/msquic/msquic/bin/Release/libmsquic.so.2 /usr/local/lib/
-COPY --from=builder /tmp/zeromq/zeromq-4.3.4/build/lib/libzmq*  /usr/local/lib/
-COPY --from=builder /tmp/zeromq/zeromq-4.3.4/include/zmq*    /usr/local/include/
 COPY etc/nanomq.conf /etc/nanomq.conf
 COPY etc/nanomq_gateway.conf /etc/nanomq_gateway.conf 
 COPY deploy/docker/docker-entrypoint.sh /usr/bin/docker-entrypoint.sh

--- a/deploy/docker/Dockerfile-dev
+++ b/deploy/docker/Dockerfile-dev
@@ -25,6 +25,7 @@ WORKDIR /nanomq/build
 RUN cmake -DENABLE_JWT=ON \
     -DNNG_ENABLE_TLS=ON \
     -DNNG_ENABLE_QUIC=ON \
+    -DQUIC_BUILD_SHARED=OFF \
     -DQUIC_USE_SYSTEM_LIBCRYPTO=ON \
     -DNNG_ENABLE_SQLITE=ON \
     -DBUILD_ZMQ_GATEWAY=ON \
@@ -37,7 +38,6 @@ WORKDIR /usr/local/nanomq
 
 COPY --from=builder /nanomq/build/nanomq/nanomq /usr/local/nanomq/
 COPY --from=builder /nanomq/build/nanomq_cli/nanomq_cli /usr/local/nanomq/
-COPY --from=builder /nanomq/build/nng/src/supplemental/quic/msquic/msquic/bin/Release/libmsquic.so.2 /usr/local/lib/
 COPY etc/nanomq.conf /etc/nanomq.conf
 COPY etc/nanomq_gateway.conf /etc/nanomq_gateway.conf 
 COPY deploy/docker/docker-entrypoint.sh /usr/bin/docker-entrypoint.sh

--- a/deploy/docker/Dockerfile-full
+++ b/deploy/docker/Dockerfile-full
@@ -1,4 +1,4 @@
-FROM ubuntu:22.04
+FROM ubuntu:20.04
 
 COPY nanomq-*-full.deb ./
 COPY deploy/docker/docker-entrypoint.sh /usr/bin/docker-entrypoint.sh
@@ -7,7 +7,8 @@ RUN apt-get update \
     && DEBIAN_FRONTEND=noninteractive apt-get install -y --no-install-recommends libatomic1 \
     && DEBIAN_FRONTEND=noninteractive apt-get install -y --no-install-recommends ./nanomq-*-linux-$(dpkg --print-architecture)-full.deb \
     && rm -rf /var/lib/apt/lists/* \
-    && rm -rf *.deb
+    && rm -rf *.deb \
+    && ldconfig
 
 EXPOSE 1883 8883 8081
 

--- a/deploy/docker/Dockerfile-full
+++ b/deploy/docker/Dockerfile-full
@@ -1,11 +1,11 @@
 FROM ubuntu:22.04
 
-COPY nanomq-*-msquic.deb ./
+COPY nanomq-*-full.deb ./
 COPY deploy/docker/docker-entrypoint.sh /usr/bin/docker-entrypoint.sh
 
 RUN apt-get update \
     && DEBIAN_FRONTEND=noninteractive apt-get install -y --no-install-recommends libatomic1 \
-    && DEBIAN_FRONTEND=noninteractive apt-get install -y --no-install-recommends ./nanomq-*-linux-$(dpkg --print-architecture)-msquic.deb \
+    && DEBIAN_FRONTEND=noninteractive apt-get install -y --no-install-recommends ./nanomq-*-linux-$(dpkg --print-architecture)-full.deb \
     && rm -rf /var/lib/apt/lists/* \
     && rm -rf *.deb
 


### PR DESCRIPTION
1. Build msquic as static library with nanomq;
2. Replace nanomq.xxx.full.deb with nanomq.xxx.msquic.deb;
3. Fix start nanomq fail on Docker containers;