### PR TITLE
Fix a use-after-free bug in sub_handler.c

### DIFF
--- a/nanomq/sub_handler.c
+++ b/nanomq/sub_handler.c
@@ -323,6 +323,7 @@ sub_ctx_handle(nano_work *work)
 			cvector_push_back(work->msg_ret, r[i]->message);
 		}
 		cvector_free(r);
+		r = NULL;
 
 	next:
 		tn = tn->next;


### PR DESCRIPTION
cvector_free will not make the freed pointer NULL. Therefore, there is a use-after-free bug in Line 320 when the if-statement in Line 314 is not executed. Note that, the if-statement in Line 317 is not executed if the pointer r is not set to NULL.