### PR TITLE
Hot updating MQTT bridge according to restapi is supported

### DIFF
--- a/nanomq/apps/broker.c
+++ b/nanomq/apps/broker.c
@@ -953,8 +953,6 @@ broker(conf *nanomq_conf)
 		for (size_t t = 0; t < nanomq_conf->bridge.count; t++) {
 			conf_bridge_node *node = nanomq_conf->bridge.nodes[t];
 			if (node->enable) {
-				nng_aio *bridge_reload_aio; // Reload aio each bridge
-				nng_aio_alloc(&bridge_reload_aio, NULL, NULL);
 				bridge_sock = node->sock;
 				for (i = tmp; i < (tmp + node->parallel);
 				     i++) {
@@ -962,9 +960,7 @@ broker(conf *nanomq_conf)
 					    inproc_sock, *bridge_sock,
 					    PROTO_MQTT_BRIDGE, db, db_ret,
 					    nanomq_conf);
-					works[i]->bridge_reload_aio = bridge_reload_aio;
 				}
-				node->bridge_reload_aio = bridge_reload_aio;
 				tmp += node->parallel;
 			}
 		}

--- a/nanomq/bridge.c
+++ b/nanomq/bridge.c
@@ -38,32 +38,6 @@ static nng_thread *hybridger_thr;
 
 static void quic_ack_cb(void *arg);
 
-struct reload_arg {
-	bool              ready;
-	nng_socket       *sock;
-	conf             *config;
-	conf_bridge_node *node;
-
-	nng_mtx          *mtx;
-} reload_arg;
-
-static void
-init_reload_arg()
-{
-	reload_arg.ready   = false;
-	reload_arg.sock    = NULL;
-	reload_arg.config  = NULL;
-	reload_arg.node    = NULL;
-
-	nng_mtx_alloc(&reload_arg.mtx);
-}
-
-static void
-fini_reload_arg()
-{
-	nng_mtx_free(reload_arg.mtx);
-}
-
 static int
 apply_sqlite_config(
     nng_socket *sock, conf_bridge_node *config, const char *db_name)
@@ -1071,8 +1045,6 @@ bridge_unsubscribe(nng_socket *sock, conf_bridge_node *node,
 int
 bridge_reload(nng_socket *sock, conf *config, conf_bridge_node *node)
 {
-	int  rv;
-	bool status;
 	if (node->address == NULL)
 		return -1;
 

--- a/nanomq/include/broker.h
+++ b/nanomq/include/broker.h
@@ -51,7 +51,6 @@ struct work {
 	reason_code code; // MQTT reason code
 
 	nng_socket webhook_sock;
-	nng_aio *  bridge_reload_aio;
 
 	struct pipe_content *     pipe_ct;
 	conn_param *              cparam;

--- a/nanomq/rest_api.c
+++ b/nanomq/rest_api.c
@@ -3046,7 +3046,6 @@ put_mqtt_bridge(http_msg *msg, const char *name)
 		conf_bridge_node_destroy(node);
 		conf_bridge_node_parse(node, &bridge->sqlite, node_obj);
 		node->parallel = parallel;
-		// node->name = name;
 		nng_mtx_unlock(node->mtx);
 
 		found = true;

--- a/nanomq/rest_api.c
+++ b/nanomq/rest_api.c
@@ -27,10 +27,12 @@
 #include "nng/supplemental/http/http.h"
 #include "nng/supplemental/util/platform.h"
 #include "nng/supplemental/nanolib/log.h"
+
 #include <stdint.h>
 #include <stdio.h>
 #include <string.h>
 #include <time.h>
+#include <unistd.h>
 
 #ifdef SUPP_JWT
 #include "l8w8jwt/decode.h"

--- a/nanomq/rest_api.c
+++ b/nanomq/rest_api.c
@@ -3027,7 +3027,7 @@ put_mqtt_bridge(http_msg *msg, const char *name)
 		return error_response(msg, NNG_HTTP_STATUS_BAD_REQUEST,
 		    REQ_PARAMS_JSON_FORMAT_ILLEGAL);
 	}
-	cJSON *node_obj = cJSON_GetObjectItem(req, "data");
+	cJSON *node_obj = cJSON_GetObjectItem(req, name);
 	conf * config   = get_global_conf();
 
 	bool         found  = false;
@@ -3046,6 +3046,7 @@ put_mqtt_bridge(http_msg *msg, const char *name)
 		conf_bridge_node_destroy(node);
 		conf_bridge_node_parse(node, &bridge->sqlite, node_obj);
 		node->parallel = parallel;
+		// node->name = name;
 		nng_mtx_unlock(node->mtx);
 
 		found = true;

--- a/nanomq/rest_api.c
+++ b/nanomq/rest_api.c
@@ -3279,11 +3279,11 @@ post_mqtt_bridge_sub(http_msg *msg, const char *name)
 		found = true;
 
 		// convert sub_topics to nng_mqtt_topic_qos
-		// TODO uncomment the following line if you want to use nng_mqtt_topic_qos
-		// nng_mqtt_topic_qos *topic_list = convert_topic_qos(node->sub_list, node->sub_count);
+		nng_mqtt_topic_qos *topic_list = convert_topic_qos(node->sub_list, node->sub_count);
 
-		// TODO @Wangha handle subscribe
+		// handle subscribe
 		// TODO params: config, node, node->sock, topic_list, sub_count, prop_list
+		bridge_subscribe(node->sock, node, topic_list, sub_count, prop_list);
 		break;
 	}
 
@@ -3405,11 +3405,11 @@ post_mqtt_bridge_unsub(http_msg *msg, const char *name)
 
 		found = true;
 		// convert unsub_topics to nng_mqtt_topic
-		// TODO uncomment the following line if you want to use nng_mqtt_topic
-		// nng_mqtt_topic *topic_list = convert_topic(unsub_topics, unsub_count);
+		nng_mqtt_topic *topic_list = convert_topic(unsub_topics, unsub_count);
 
-		// TODO @Wangha handle unsubscribe
+		// handle unsubscribe
 		// TODO params: config, node, node->sock, topic_list, unsub_count, prop_list
+		bridge_unsubscribe(node->sock, node, topic_list, unsub_count, prop_list);
 		break;
 	}
 


### PR DESCRIPTION
* Hot updating MQTT bridge according to restapi is supported
* Revert #1188.
* Add an independent thread to control the updating of bridge.
* Remove some useless code in Restapi.
* Add mutex for conf_bridge_node.
* Print all the result codes in suback/unsuback.
* Add dynamic sub/unsub interfaces to update the subscriptions of the bridge.
