### PR TITLE
chore: dump gcc 11.3 in docker

### DIFF
--- a/.github/workflows/build_packages.yaml
+++ b/.github/workflows/build_packages.yaml
@@ -16,6 +16,7 @@ jobs:
     runs-on: ubuntu-20.04
 
     strategy:
+      fail-fast: false
       matrix:
         arch:
         - [amd64, gcc, g++, x86_64-linux-gnu, /usr/local]
@@ -45,7 +46,6 @@ jobs:
           build_type: "-full"
         - arch: [armel, arm-linux-gnueabi-gcc, arm-linux-gnueabi-g++]
           build_type: "-full"
-      fail-fast: false
 
     steps:
     - name: install toolchains
@@ -221,6 +221,7 @@ jobs:
     runs-on: ubuntu-20.04
 
     strategy:
+      fail-fast: false
       matrix:
         suffix:
         - ""

--- a/deploy/docker/Dockerfile-slim
+++ b/deploy/docker/Dockerfile-slim
@@ -1,4 +1,4 @@
-FROM gcc:11 as builder
+FROM gcc:11.3 as builder
 
 COPY . /nanomq
 


### PR DESCRIPTION
if use gcc 11.4 and debian 12, we got cmake build error