### PR TITLE
Fix the error that bridge reloads failed when url is not dialable

### DIFF
--- a/nanomq/bridge.c
+++ b/nanomq/bridge.c
@@ -1280,7 +1280,7 @@ bridge_reload(nng_socket *sock, conf *config, conf_bridge_node *node)
 	nng_send_aio(*sock, client->send_aio);
 	log_info("bridge send disconnect to broker");
 	// Wait for the disconnect msg be sent
-	nng_aio_wait(client->send_aio);
+	// nng_aio_wait(client->send_aio);
 
 	nng_mtx_lock(reload_lock);
 	node->enable = false;


### PR DESCRIPTION
* FIX [bridge] Fix the error that bridge reloads failed when url is not dialable

Note. After these changes. We don't wait to disconnect msg to be sent.

Which needs this pr in nanonng. https://github.com/nanomq/NanoNNG/pull/620