### PR TITLE
Add time and trace to the logs in dds2mqtt & support setting partition

### DIFF
--- a/etc/nanomq_dds_gateway.conf
+++ b/etc/nanomq_dds_gateway.conf
@@ -1,7 +1,7 @@
 # Example1. (default)
 # This configure will make msgs with topic topic1 be shared in DDS network and MQTT network.
 # It receive messages from MQTT network in topic DDSCMD/topic1 and send them to DDS network with topic MQTT/topic1.
-# It receive messages from DDS network in topic MQTTCMD/topic1 and send them to MQTT network with topic DDS/topic1. 
+# It receive messages from DDS network in topic MQTTCMD/topic1 and send them to MQTT network with topic DDS/topic1.
 
 forward_rules = {
     dds_to_mqtt = {
@@ -9,7 +9,7 @@ forward_rules = {
         to_mqtt = "DDS/topic1"
         struct_name = "example_struct"
     }
-    
+
     mqtt_to_dds = {
         from_mqtt = "DDSCMD/topic1"
         to_dds = "MQTT/topic1"
@@ -22,7 +22,17 @@ dds {
     # # default: 0
     # # Value: uint32
     domain_id = 0
-    
+
+    # # dds subscriber partition. Setting multiple partitions is not supported yet.
+    # # default: "partition"
+    # # Value: string
+    subscriber_partition = "partition"
+
+    # # dds publisher partition. Setting multiple partitions is not supported yet.
+    # # default: "partition"
+    # # Value: string
+    publisher_partition = "partition"
+
     shared_memory = {
         # # Enable shared memory transport.
         # # Iceoryx is required if enable shared memory transport.
@@ -30,7 +40,7 @@ dds {
         # # Default: false
         # # Value:  boolean
         enable = false
-        
+
         # # controls the output of the iceoryx runtime and can be set to, in order of decreasing output:
         # # log level: verbose, debug, info, warn, error, fatal, off
         # # Default:  info
@@ -47,7 +57,7 @@ mqtt {
         # # Example: mqtt-tcp://127.0.0.1:1883
         # #          tls+mqtt-tcp://127.0.0.1:8883
         server = "mqtt-tcp://127.0.0.1:1883"
-        
+
         # # Protocol version of the bridge.
         # #
         # # Value: Enum
@@ -60,7 +70,7 @@ mqtt {
         # #
         # # Value: String
         # clientid="bridge_client"
-        
+
         # # Ping: interval of a downward bridge.
         # #
         # # Value: Duration
@@ -82,7 +92,7 @@ mqtt {
         # #
         # # Value: String
         password = passwd
-        
+
         // ssl {
         //     # # Ssl key password
         //     # # String containing the user's password. Only used if the private keyfile
@@ -101,8 +111,8 @@ mqtt {
         //     # # Value: File
         //     certfile = "/etc/certs/cert.pem"
         //     # # Ssl ca cert file
-        //     # # Path of the file containing the server's root CA certificate.  
-        //     # # 
+        //     # # Path of the file containing the server's root CA certificate.
+        //     # #
         //     # # This certificate is used to identify the AWS IoT server and is publicly
         //     # # available.
         //     # #
@@ -127,7 +137,7 @@ http_server {
 	parallel = 2
 	# # username
 	# #
-    # # Basic authorization 
+    # # Basic authorization
     # #
 	# # Value: String
 	username = admin

--- a/nanomq_cli/dds2mqtt/dds_client.c
+++ b/nanomq_cli/dds2mqtt/dds_client.c
@@ -184,6 +184,11 @@ dds_proxy(int argc, char **argv)
 
 		start_rest_server(info);
 	}
+	// Partition must be set
+	if (!config->dds.subscriber_partition)
+		config->dds.subscriber_partition = strdup("partition");
+	if (!config->dds.publisher_partition)
+		config->dds.publisher_partition = strdup("partition");
 
 	/* Configuration from file */
 	log_dds("[mqtt]");
@@ -191,6 +196,8 @@ dds_proxy(int argc, char **argv)
 
 	log_dds("[dds]");
 	log_dds("domain.id. %ld", config->dds.domain_id);
+	log_dds("subscriber.partition. %s", config->dds.subscriber_partition);
+	log_dds("publisher.partition. %s", config->dds.publisher_partition);
 
 	log_dds("[topic forward rules]");
 	log_dds("dds2mqtt. %s => %s", config->forward.dds2mqtt.from, config->forward.dds2mqtt.to);

--- a/nanomq_cli/dds2mqtt/dds_client.c
+++ b/nanomq_cli/dds2mqtt/dds_client.c
@@ -380,7 +380,6 @@ dds_client(dds_cli *cli, mqtt_cli *mqttcli)
 			/* Print Message. */
 			log_dds("=== [Subscriber] Received struct '%s'",
 			    dds_reader_handles->desc->m_typename);
-			fflush(stdout);
 
 			/* Make a handle */
 			hd = mk_handle(HANDLE_TO_MQTT, samples[0], 0);

--- a/nanomq_cli/dds2mqtt/dds_client.c
+++ b/nanomq_cli/dds2mqtt/dds_client.c
@@ -168,15 +168,14 @@ dds_proxy(int argc, char **argv)
 	conf_dds_gateway_init(config);
 
 	if (cmd_parse_opts(argc, argv, &config->path) == 0) {
-		fprintf(stderr, "invalid options.\n");
+		log_dds("invalid options.");
 		exit(1);
 	}
 	conf_dds_gateway_parse_ver2(config);
 	if (config->path == NULL) {
-		fprintf(stderr, "Configuration file is required.\n");
-		fprintf(stderr,
-		    "Please specify a configuration file with '--conf "
-		    "<path>' \n");
+		log_dds("Configuration file is required.");
+		log_dds("Please specify a configuration file with '--conf "
+		    "<path>'");
 		exit(1);
 	}
 	if (config->http_server.enable) {
@@ -187,15 +186,15 @@ dds_proxy(int argc, char **argv)
 	}
 
 	/* Configuration from file */
-	printf("[mqtt]\n");
-	printf("broker.url. %s\n", config->mqtt.address);
+	log_dds("[mqtt]");
+	log_dds("broker.url. %s", config->mqtt.address);
 
-	printf("[dds]\n");
-	printf("domain.id. %ld\n", config->dds.domain_id);
+	log_dds("[dds]");
+	log_dds("domain.id. %ld", config->dds.domain_id);
 
-	printf("[topic forward rules]\n");
-	printf("dds2mqtt. %s => %s\n", config->forward.dds2mqtt.from, config->forward.dds2mqtt.to);
-	printf("mqtt2dds. %s => %s\n", config->forward.mqtt2dds.from, config->forward.mqtt2dds.to);
+	log_dds("[topic forward rules]");
+	log_dds("dds2mqtt. %s => %s", config->forward.dds2mqtt.from, config->forward.dds2mqtt.to);
+	log_dds("mqtt2dds. %s => %s", config->forward.mqtt2dds.from, config->forward.mqtt2dds.to);
 
 	dds_client_init(&ddscli, config);
 
@@ -307,7 +306,7 @@ dds_client(dds_cli *cli, mqtt_cli *mqttcli)
 		DDS_FATAL("dds_create_reader: %s\n", dds_strretcode(-reader));
 	dds_delete_qos(qosr);
 
-	printf("\n=== [Subscriber] Started\n");
+	log_dds("=== [Subscriber] Started");
 	fflush(stdout);
 
 	/* Qos for Publisher */
@@ -338,7 +337,7 @@ dds_client(dds_cli *cli, mqtt_cli *mqttcli)
 	if (writer < 0)
 		DDS_FATAL("dds_create_writer: %s\n", dds_strretcode(-writer));
 
-	printf("=== [Publisher] Started\n");
+	log_dds("=== [Publisher] Started");
 	fflush(stdout);
 
 	rc = dds_set_status_mask(writer, DDS_PUBLICATION_MATCHED_STATUS);
@@ -379,7 +378,7 @@ dds_client(dds_cli *cli, mqtt_cli *mqttcli)
 		/* Check if we read some data and it is valid. */
 		if ((rc > 0) && (infos[0].valid_data)) {
 			/* Print Message. */
-			printf("=== [Subscriber] Received struct '%s'\n",
+			log_dds("=== [Subscriber] Received struct '%s'\n",
 			    dds_reader_handles->desc->m_typename);
 			fflush(stdout);
 
@@ -414,7 +413,7 @@ dds_client(dds_cli *cli, mqtt_cli *mqttcli)
 			if (rc != DDS_RETCODE_OK)
 				DDS_FATAL(
 				    "dds_write: %s\n", dds_strretcode(-rc));
-			printf("[DDS] Send a msg to dds.\n");
+			log_dds("[DDS] Send a msg to dds.");
 			free(hd);
 			break;
 		case HANDLE_TO_MQTT:
@@ -422,10 +421,10 @@ dds_client(dds_cli *cli, mqtt_cli *mqttcli)
 			pthread_mutex_lock(&mqttcli->mtx);
 			nftp_vec_append(mqttcli->handleq, hd);
 			pthread_mutex_unlock(&mqttcli->mtx);
-			printf("[DDS] Send a msg to mqtt.\n");
+			log_dds("[DDS] Send a msg to mqtt.\n");
 			break;
 		default:
-			printf("Unsupported handle type.\n");
+			log_dds("Unsupported handle type.\n");
 			break;
 		}
 	}

--- a/nanomq_cli/dds2mqtt/dds_client.c
+++ b/nanomq_cli/dds2mqtt/dds_client.c
@@ -378,7 +378,7 @@ dds_client(dds_cli *cli, mqtt_cli *mqttcli)
 		/* Check if we read some data and it is valid. */
 		if ((rc > 0) && (infos[0].valid_data)) {
 			/* Print Message. */
-			log_dds("=== [Subscriber] Received struct '%s'\n",
+			log_dds("=== [Subscriber] Received struct '%s'",
 			    dds_reader_handles->desc->m_typename);
 			fflush(stdout);
 
@@ -421,7 +421,7 @@ dds_client(dds_cli *cli, mqtt_cli *mqttcli)
 			pthread_mutex_lock(&mqttcli->mtx);
 			nftp_vec_append(mqttcli->handleq, hd);
 			pthread_mutex_unlock(&mqttcli->mtx);
-			log_dds("[DDS] Send a msg to mqtt.\n");
+			log_dds("[DDS] Send a msg to mqtt.");
 			break;
 		default:
 			log_dds("Unsupported handle type.\n");

--- a/nanomq_cli/dds2mqtt/dds_utils.c
+++ b/nanomq_cli/dds2mqtt/dds_utils.c
@@ -16,12 +16,13 @@
 
 enum options {
 	OPT_DDS_HELP = 1,
-    OPT_DDS_DOMAIN_ID,
-    OPT_DDS_TOPIC,
+	OPT_DDS_DOMAIN_ID,
+	OPT_DDS_TOPIC,
 	OPT_DDS_STRUCT_NAME,
 	OPT_DDS_MSG,
-    OPT_DDS_SHM_MODE,
-    OPT_DDS_SHM_LOG_LEVEL,
+	OPT_DDS_SHM_MODE,
+	OPT_DDS_SHM_LOG_LEVEL,
+	OPT_DDS_PARTITION,
 	OPT_DDS_INVALID,
 };
 
@@ -64,6 +65,12 @@ static nng_optspec cmd_opts[] = {
 	    .o_name  = "shm_log_level",
 	    .o_short = 'l',
 	    .o_val   = OPT_DDS_SHM_LOG_LEVEL,
+	    .o_arg   = true,
+	},
+	{
+	    .o_name  = "partition",
+	    .o_short = 'p',
+	    .o_val   = OPT_DDS_PARTITION,
 	    .o_arg   = true,
 	},
 	{
@@ -135,6 +142,13 @@ dds_cmd_parse_opts(int argc, char **argv, dds_client_opts *opts)
 			opts->shm_log_level = nng_strdup(arg);
 			break;
 
+		case OPT_DDS_PARTITION:
+			if (opts->partition != NULL) {
+				nng_strfree(opts->partition);
+			}
+			opts->partition = nng_strdup(arg);
+			break;
+
 		default:
 			break;
 		}
@@ -174,7 +188,8 @@ help(dds_client_type cli_type)
 	printf("Usage: \n"
 	       "nanomq_cli ddsproxy %s -t <topic> -n <struct> \n"
 	       "       [-h, --help] [-d, --domain_id <domain id>] \n"
-           "       [-s, --shm_mode] [-l, --shm_log_level <level>]\n\n",
+           "       [-s, --shm_mode] [-l, --shm_log_level <level>]\n",
+           "       [-p, --partition <partition name>]\n\n",
 	    cli_type == DDS_PUB ? "pub" : "sub");
 
 	printf("Requirements: \n");
@@ -197,6 +212,8 @@ help(dds_client_type cli_type)
 	printf("\t                               (verbose, debug, info, warn, "
 	       "error, fatal, off)\n");
 	printf("\t                               (default: info)\n");
+	printf("\t-p, --partition <partition>    Specify a DDS Partition name"
+	       "(default: partition)\n");
 	printf("\n");
 }
 
@@ -208,6 +225,7 @@ dds_handle_cmd(
 	opts->topic         = NULL;
 	opts->shm_mode      = false;
 	opts->shm_log_level = NULL;
+	opts->partition     = NULL;
 
 	if (!dds_cmd_parse_opts(argc, argv, opts)) {
 		help(opts->cli_type);

--- a/nanomq_cli/dds2mqtt/dds_utils.h
+++ b/nanomq_cli/dds2mqtt/dds_utils.h
@@ -20,6 +20,7 @@ typedef struct {
 	cJSON *         msg;
 	bool            shm_mode;
 	char *          shm_log_level;
+	char *          partition;
 } dds_client_opts;
 
 // It should not be changed

--- a/nanomq_cli/dds2mqtt/mqtt_client.c
+++ b/nanomq_cli/dds2mqtt/mqtt_client.c
@@ -286,6 +286,13 @@ mqtt_recv_loop(void *arg)
 			continue;
 
 		pthread_mutex_lock(&rmsgq_mtx);
+		if (nftp_vec_len(rmsgq) * 4 == nftp_vec_cap(rmsgq)) {
+			log_dds("WARNING 1 / 4 of the queue from MQTT to DDS is used.");
+		} else if (nftp_vec_len(rmsgq) * 2 == nftp_vec_cap(rmsgq)) {
+			log_dds("WARNING 1 / 2 of the queue from MQTT to DDS is used.");
+		} else if (nftp_vec_len(rmsgq) == nftp_vec_cap(rmsgq)) {
+			log_dds("WARNING All of the queue from MQTT to DDS is used. Drop msg.");
+		}
 		nftp_vec_append(rmsgq, msg);
 		pthread_mutex_unlock(&rmsgq_mtx);
 	}

--- a/nanomq_cli/dds2mqtt/mqtt_client.c
+++ b/nanomq_cli/dds2mqtt/mqtt_client.c
@@ -133,18 +133,18 @@ client_connect(
 
 	if (mqtt_conf->proto_ver == 5) {
 		if ((rv = nng_mqttv5_client_open(sock)) != 0) {
-			log_dds("nng_socket: %s", nng_strerror(rv));
+			log_dds("nng_socket: %s\n", nng_strerror(rv));
 		}
 	} else {
 		if ((rv = nng_mqtt_client_open(sock)) != 0) {
-			log_dds("nng_socket: %s", nng_strerror(rv));
+			log_dds("nng_socket: %s\n", nng_strerror(rv));
 		}
 	}
 
 	mqtt_conf->sock = sock;
 
 	if ((rv = nng_dialer_create(dialer, *sock, mqtt_conf->address)) != 0) {
-		log_dds("nng_dialer_create: %s", nng_strerror(rv));
+		log_dds("nng_dialer_create: %s\n", nng_strerror(rv));
 	}
 
 	cli->client = nng_mqtt_client_alloc(cli->sock, &send_callback, true);
@@ -215,12 +215,12 @@ client_publish(nng_socket sock, const char *topic, uint8_t *payload,
 	if (verbose) {
 		uint8_t print[1024] = { 0 };
 		nng_mqtt_msg_dump(pubmsg, print, 1024, true);
-		log_dds("%s\n", print);
+		log_dds("%s", print);
 	}
 
-	log_dds("Publishing to '%s' ...\n", topic);
+	log_dds("Publishing to '%s' ...", topic);
 	if ((rv = nng_sendmsg(sock, pubmsg, NNG_FLAG_NONBLOCK)) != 0) {
-		log_dds("nng_sendmsg: %s", nng_strerror(rv));
+		log_dds("nng_sendmsg: %s\n", nng_strerror(rv));
 	}
 
 	return rv;
@@ -253,7 +253,7 @@ client_recv2(mqtt_cli *cli, nng_msg **msgp)
 	int      rv;
 	nng_msg *msg;
 	if ((rv = nng_recvmsg(cli->sock, &msg, NNG_FLAG_NONBLOCK)) != 0) {
-		log_dds("[MQTT] Error in nng_recvmsg %d.\n", rv);
+		log_dds("[MQTT] Error in nng_recvmsg %d.", rv);
 		return -1;
 	}
 
@@ -264,10 +264,10 @@ client_recv2(mqtt_cli *cli, nng_msg **msgp)
 		return -2;
 	}
 
-	log_dds("[MQTT] Receive mqtt message\n");
+	log_dds("[MQTT] Receive mqtt message");
 
 	if (type != NNG_MQTT_PUBLISH) {
-		log_dds("[MQTT] Received a %x type msg. Skip.\n", type);
+		log_dds("[MQTT] Received a %x type msg. Skip.", type);
 		return -3;
 	}
 
@@ -324,7 +324,7 @@ mqtt_loop(void *arg)
 
 		rv = client_recv(cli, &msg);
 		if (rv < 0) {
-			log_dds("Errror in recv msg\n");
+			log_dds("Error in recv msg\n");
 			continue;
 		} else if (rv == 0) {
 			// Received msg and put to handleq
@@ -349,12 +349,12 @@ mqtt_loop(void *arg)
 			nftp_vec_append(ddscli->handleq, (void *) hd);
 			pthread_mutex_unlock(&ddscli->mtx);
 
-			log_dds("[MQTT] send msg to dds.\n");
+			log_dds("[MQTT] send msg to dds.");
 			break;
 		case HANDLE_TO_MQTT:
 			// Translate DDS msg to MQTT format
 			ddsmsg = hd->data;
-			log_dds("[MQTT] send msg to mqtt.\n");
+			log_dds("[MQTT] send msg to mqtt.");
 			// dds_to_mqtt_type_convert(ddsmsg, &mqttmsg);
 			cJSON *json = dds_handlers->dds2mqtt(ddsmsg);
 			dds_handlers->free(ddsmsg, DDS_FREE_ALL);

--- a/nanomq_cli/dds2mqtt/mqtt_client.c
+++ b/nanomq_cli/dds2mqtt/mqtt_client.c
@@ -346,7 +346,7 @@ mqtt_loop(void *arg)
 		// else No msgs available
 
 		// Sleep and continue
-		nng_msleep(500);
+		nng_msleep(200);
 		continue;
 	work:
 		switch (hd->type) {

--- a/nanomq_cli/dds2mqtt/publisher.c
+++ b/nanomq_cli/dds2mqtt/publisher.c
@@ -59,6 +59,8 @@ dds_publisher(int argc, char **argv)
 
 	/* Qos for Publisher */
 	qospub = dds_create_qos();
+	if (opts.partition != NULL)
+		partitionspub[0] = opts.partition;
 	dds_qset_partition(qospub, 1, partitionspub);
 
 	/* Create the Publisher. */

--- a/nanomq_cli/dds2mqtt/subscriber.c
+++ b/nanomq_cli/dds2mqtt/subscriber.c
@@ -61,6 +61,8 @@ dds_subscriber(int argc, char **argv)
 
 	/* Qos for Subscriber */
 	qossub = dds_create_qos();
+	if (opts.partition != NULL)
+		partitionssub[0] = opts.partition;
 	dds_qset_partition(qossub, 1, partitionssub);
 
 	/* Create the Subscriber */

--- a/nanomq_cli/dds2mqtt/vector.h
+++ b/nanomq_cli/dds2mqtt/vector.h
@@ -17,11 +17,6 @@
 #if defined(SUPP_DDS_PROXY)
 
 #define NFTP_SIZE         128
-#define NFTP_BLOCK_SZ     (256 * 1024) // Maximal size of single package
-#define NFTP_FILES        32 // Receive up to 32 files at once
-#define NFTP_HASH(p, n)   nftp_djb_hashn(p, n)
-#define NFTP_FNAME_LEN    64
-#define NFTP_FDIR_LEN     256
 
 enum NFTP_ERR {
 	NFTP_ERR_HASH = 0x01,

--- a/nanomq_cli/dds2mqtt/vector.h
+++ b/nanomq_cli/dds2mqtt/vector.h
@@ -61,6 +61,14 @@ int nftp_vec_cat(nftp_vec *, nftp_vec *);
 size_t nftp_vec_cap(nftp_vec *);
 size_t nftp_vec_len(nftp_vec *);
 
+#define __FILENAME__ (strrchr(__FILE__, '/') ? strrchr(__FILE__, '/') + 1 : __FILE__)
+
+#define log_dds(format, arg...)                         \
+	do {                                                    \
+		fprintf(stderr, "%s:%d(%s) " format "\n", __FILENAME__, \
+		    __LINE__, __FUNCTION__, ##arg);                     \
+	} while (0)
+
 #endif
 
 #endif

--- a/nanomq_cli/dds2mqtt/vector.h
+++ b/nanomq_cli/dds2mqtt/vector.h
@@ -12,6 +12,7 @@
 #define DDS2MQTT_VECTOR
 
 #include <stdlib.h>
+#include <time.h>
 
 #if defined(SUPP_DDS_PROXY)
 
@@ -63,10 +64,22 @@ size_t nftp_vec_len(nftp_vec *);
 
 #define __FILENAME__ (strrchr(__FILE__, '/') ? strrchr(__FILE__, '/') + 1 : __FILE__)
 
+char buf[64];
+static inline char *
+now()
+{
+	time_t timer;
+	struct tm *tm_info;
+	timer = time(NULL);
+	tm_info = localtime(&timer);
+	strftime(buf, sizeof(buf), "%Y-%m-%d %H:%M:%S", tm_info);
+	return buf;
+}
+
 #define log_dds(format, arg...)                         \
 	do {                                                    \
-		fprintf(stderr, "%s:%d(%s) " format "\n", __FILENAME__, \
-		    __LINE__, __FUNCTION__, ##arg);                     \
+		fprintf(stderr, "%s %s:%d(%s) " format "\n", now(), \
+		    __FILENAME__, __LINE__, __FUNCTION__, ##arg);   \
 	} while (0)
 
 #endif


### PR DESCRIPTION
* Add time and trace information to the logs in dds2mqtt
* Add water level warnings for the queue of mqtt to dds.
* Support subscriber partition name in the configuration file.
* Support publisher partition name in the configuration file.
* Clean the logs